### PR TITLE
Disable the jump of both submit button and hyperlinks with empty hash…

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,10 +497,10 @@
                                 <i class="fa fa-cog"></i> Settings</a>
 
                             <div class="btn-group">
-                                <a class="btn btn-default disable-anchor" href="#"><i class="fa fa-align-left"></i></a>
-                                <a class="btn btn-default disable-anchor" href="#"><i class="fa fa-align-center"></i></a>
-                                <a class="btn btn-default disable-anchor" href="#"><i class="fa fa-align-right"></i></a>
-                                <a class="btn btn-default disable-anchor" href="#"><i class="fa fa-align-justify"></i></a>
+                                <a class="btn btn-default " href="#"><i class="fa fa-align-left"></i></a>
+                                <a class="btn btn-default " href="#"><i class="fa fa-align-center"></i></a>
+                                <a class="btn btn-default " href="#"><i class="fa fa-align-right"></i></a>
+                                <a class="btn btn-default " href="#"><i class="fa fa-align-justify"></i></a>
                             </div>
 
                             <div class="input-group margin-bottom-sm">
@@ -822,7 +822,7 @@
                                             <div class="form-group">
                                                 <input type="text" class="form-control" placeholder="Search">
                                             </div>
-                                            <button type="submit"  class="btn btn-default">Submit</button>
+                                            <button type="submit" class="btn btn-default">Submit</button>
                                         </form>
 
                                         <ul class="nav navbar-nav navbar-right">

--- a/index.html
+++ b/index.html
@@ -497,10 +497,10 @@
                                 <i class="fa fa-cog"></i> Settings</a>
 
                             <div class="btn-group">
-                                <a class="btn btn-default " href="#"><i class="fa fa-align-left"></i></a>
-                                <a class="btn btn-default " href="#"><i class="fa fa-align-center"></i></a>
-                                <a class="btn btn-default " href="#"><i class="fa fa-align-right"></i></a>
-                                <a class="btn btn-default " href="#"><i class="fa fa-align-justify"></i></a>
+                                <a class="btn btn-default" href="#"><i class="fa fa-align-left"></i></a>
+                                <a class="btn btn-default" href="#"><i class="fa fa-align-center"></i></a>
+                                <a class="btn btn-default" href="#"><i class="fa fa-align-right"></i></a>
+                                <a class="btn btn-default" href="#"><i class="fa fa-align-justify"></i></a>
                             </div>
 
                             <div class="input-group margin-bottom-sm">

--- a/index.html
+++ b/index.html
@@ -497,10 +497,10 @@
                                 <i class="fa fa-cog"></i> Settings</a>
 
                             <div class="btn-group">
-                                <a class="btn btn-default" href="#"><i class="fa fa-align-left"></i></a>
-                                <a class="btn btn-default" href="#"><i class="fa fa-align-center"></i></a>
-                                <a class="btn btn-default" href="#"><i class="fa fa-align-right"></i></a>
-                                <a class="btn btn-default" href="#"><i class="fa fa-align-justify"></i></a>
+                                <a class="btn btn-default disable-anchor" href="#"><i class="fa fa-align-left"></i></a>
+                                <a class="btn btn-default disable-anchor" href="#"><i class="fa fa-align-center"></i></a>
+                                <a class="btn btn-default disable-anchor" href="#"><i class="fa fa-align-right"></i></a>
+                                <a class="btn btn-default disable-anchor" href="#"><i class="fa fa-align-justify"></i></a>
                             </div>
 
                             <div class="input-group margin-bottom-sm">
@@ -822,7 +822,7 @@
                                             <div class="form-group">
                                                 <input type="text" class="form-control" placeholder="Search">
                                             </div>
-                                            <button type="submit" class="btn btn-default">Submit</button>
+                                            <button type="submit"  class="btn btn-default">Submit</button>
                                         </form>
 
                                         <ul class="nav navbar-nav navbar-right">
@@ -1199,6 +1199,12 @@
 <script src="vendor/prism/prism.js"></script>
 <script type="text/javascript">
     $('body').scrollspy({ target: '#side-menu' , offset : 100})
+    var disableEvent = function(e) {
+       e.preventDefault();
+    }
+    $('a[href="#"]').click(disableEvent);
+    $('button[type="submit"]').click(disableEvent);
+
 </script>
 
 </body>


### PR DESCRIPTION
### Issue
In the example of dropdown menu, it has clickable hyperlink -- `href="#"`. Every time we click it, it will jump to the top of the page, which is what we expected. Similar as the submit button on nav bar, we also need to disable the event after clicking.

### Solution
Disable the default event after user click.